### PR TITLE
Add commands to Pi configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "pi": {
     "extensions": ["./pi-extensions"],
     "skills": ["./skills"],
+    "prompts": ["./commands"],
     "themes": ["./pi-themes"]
   },
   "peerDependencies": {


### PR DESCRIPTION
I wonder if the commands were intentionally left out of package.json. Some of the commands reference `./.claude`, such as `/handoff` and `/pickup`.