### PR TITLE
feat(todos): add left/right arrow keys for page up/down in detail overlay

### DIFF
--- a/pi-extensions/todos.ts
+++ b/pi-extensions/todos.ts
@@ -590,11 +590,11 @@ class TodoDetailOverlayComponent {
 			this.scrollBy(1);
 			return;
 		}
-		if (kb.matches(keyData, "selectPageUp")) {
+		if (kb.matches(keyData, "selectPageUp") || matchesKey(keyData, Key.left)) {
 			this.scrollBy(-this.viewHeight || -1);
 			return;
 		}
-		if (kb.matches(keyData, "selectPageDown")) {
+		if (kb.matches(keyData, "selectPageDown") || matchesKey(keyData, Key.right)) {
 			this.scrollBy(this.viewHeight || 1);
 			return;
 		}
@@ -685,7 +685,8 @@ class TodoDetailOverlayComponent {
 	private buildActionLine(width: number): string {
 		const work = this.theme.fg("accent", "enter") + this.theme.fg("muted", " work on todo");
 		const back = this.theme.fg("dim", "esc back");
-		const pieces = [work, back];
+		const nav = this.theme.fg("dim", "↑/↓: move. ←/→: page.");
+		const pieces = [work, back, nav];
 
 		let line = pieces.join(this.theme.fg("muted", " • "));
 		if (this.totalLines > this.viewHeight) {


### PR DESCRIPTION
- Support left/right arrow keys for page up/down
- Add nav indicators on the action line

<img width="899" height="766" alt="CleanShot 2026-03-10 at 15 13 28" src="https://github.com/user-attachments/assets/2623a3a5-668e-4b8a-9535-ce5b08c1468c" />
