### PR TITLE
fix(control): refresh session-control on fork

### DIFF
--- a/pi-extensions/control.ts
+++ b/pi-extensions/control.ts
@@ -1060,6 +1060,10 @@ export default function (pi: ExtensionAPI) {
 		await refreshServer(ctx);
 	});
 
+	pi.on("session_fork", async (_event, ctx) => {
+		await refreshServer(ctx);
+	});
+
 	pi.on("session_shutdown", async () => {
 		if (state.aliasTimer) {
 			clearInterval(state.aliasTimer);


### PR DESCRIPTION
Pi emits `session_fork` after assigning a new session id.

`control.ts` refreshes its state on `session_start` and `session_switch`, but not on `session_fork`. As a result, after `/fork` the control socket state can stay bound to the old session.

This adds the same `refreshServer(ctx)` call for `session_fork`, so the session-control socket, alias/status, and `PI_SESSION_ID` stay aligned with the forked session.