### PR TITLE
fix(context): use sourceInfo path for extension lookup

### DIFF
--- a/pi-extensions/context.ts
+++ b/pi-extensions/context.ts
@@ -124,7 +124,8 @@ function buildSkillIndex(pi: ExtensionAPI, cwd: string): SkillIndexEntry[] {
 		.getCommands()
 		.filter((c) => c.source === "skill")
 		.map((c) => {
-			const p = c.path ? normalizeReadPath(c.path, cwd) : "";
+			const rawPath = c.sourceInfo?.path;
+			const p = rawPath ? normalizeReadPath(rawPath, cwd) : "";
 			return {
 				name: normalizeSkillName(c.name),
 				skillFilePath: p,
@@ -479,7 +480,7 @@ export default function contextExtension(pi: ExtensionAPI) {
 
 			const extensionsByPath = new Map<string, string[]>();
 			for (const c of extensionCmds) {
-				const p = c.path ?? "<unknown>";
+				const p = c.sourceInfo?.path ?? "<unknown>";
 				const arr = extensionsByPath.get(p) ?? [];
 				arr.push(c.name);
 				extensionsByPath.set(p, arr);


### PR DESCRIPTION
Fix displaying `Extensions (1): <unknown>` in `/context` caused by 0.62.0 API change.

<img width="849" height="300" alt="CleanShot 2026-03-23 at 14 15 43" src="https://github.com/user-attachments/assets/16a8618f-3293-45a6-ac30-db0042a18ce4" />
