### PR TITLE
fix(extensions): respect PI_CODING_AGENT_DIR in session breakdown

### DIFF
--- a/pi-extensions/session-breakdown.ts
+++ b/pi-extensions/session-breakdown.ts
@@ -1,7 +1,7 @@
 /**
  * /session-breakdown
  *
- * Interactive TUI that analyzes ~/.pi/agent/sessions (recursively, *.jsonl) and shows
+ * Interactive TUI that analyzes the configured pi sessions directory (recursively, *.jsonl) and shows
  * last 7/30/90 days of:
  * - sessions/day
  * - messages/day
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { BorderedLoader } from "@mariozechner/pi-coding-agent";
+import { BorderedLoader, getAgentDir } from "@mariozechner/pi-coding-agent";
 import {
 	Key,
 	matchesKey,
@@ -150,7 +150,7 @@ interface BreakdownData {
 	};
 }
 
-const SESSION_ROOT = path.join(os.homedir(), ".pi", "agent", "sessions");
+const SESSION_ROOT = path.join(getAgentDir(), "sessions");
 const RANGE_DAYS = [7, 30, 90] as const;
 
 type MeasurementMode = "sessions" | "messages" | "tokens";
@@ -1540,7 +1540,7 @@ class BreakdownComponent implements Component {
 
 export default function sessionBreakdownExtension(pi: ExtensionAPI) {
 	pi.registerCommand("session-breakdown", {
-		description: "Interactive breakdown of last 7/30/90 days of ~/.pi session usage (sessions/messages/tokens + cost by model)",
+		description: "Interactive breakdown of last 7/30/90 days of pi session usage (sessions/messages/tokens + cost by model)",
 		handler: async (_args, ctx: ExtensionContext) => {
 			if (!ctx.hasUI) {
 				// Non-interactive fallback: just notify.


### PR DESCRIPTION
`session-breakdown` currently reads sessions from a hard-coded `~/.pi/agent/sessions` path.

This breaks setups that override the agent dir via `PI_CODING_AGENT_DIR`, where sessions live under `<agentDir>/sessions` instead.

This change switches the extension to `getAgentDir()` so it follows pi's configured agent directory.