### PR TITLE
fix(answer): update to getApiKeyAndHeaders API (pi-coding-agent 0.63+)

### DIFF
--- a/pi-extensions/answer.ts
+++ b/pi-extensions/answer.ts
@@ -11,7 +11,7 @@
  */
 
 import { complete, type Model, type Api, type UserMessage } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { BorderedLoader } from "@mariozechner/pi-coding-agent";
 import {
 	type Component,
@@ -75,15 +75,12 @@ const HAIKU_MODEL_ID = "claude-haiku-4-5";
  */
 async function selectExtractionModel(
 	currentModel: Model<Api>,
-	modelRegistry: {
-		find: (provider: string, modelId: string) => Model<Api> | undefined;
-		getApiKey: (model: Model<Api>) => Promise<string | undefined>;
-	},
+	modelRegistry: ModelRegistry,
 ): Promise<Model<Api>> {
 	const codexModel = modelRegistry.find("openai-codex", CODEX_MODEL_ID);
 	if (codexModel) {
-		const apiKey = await modelRegistry.getApiKey(codexModel);
-		if (apiKey) {
+		const auth = await modelRegistry.getApiKeyAndHeaders(codexModel);
+		if (auth.ok && auth.apiKey) {
 			return codexModel;
 		}
 	}
@@ -93,8 +90,8 @@ async function selectExtractionModel(
 		return currentModel;
 	}
 
-	const apiKey = await modelRegistry.getApiKey(haikuModel);
-	if (!apiKey) {
+	const auth = await modelRegistry.getApiKeyAndHeaders(haikuModel);
+	if (!auth.ok || !auth.apiKey) {
 		return currentModel;
 	}
 
@@ -457,7 +454,10 @@ export default function (pi: ExtensionAPI) {
 				loader.onAbort = () => done(null);
 
 				const doExtract = async () => {
-					const apiKey = await ctx.modelRegistry.getApiKey(extractionModel);
+					const auth = await ctx.modelRegistry.getApiKeyAndHeaders(extractionModel);
+					if (!auth.ok || !auth.apiKey) {
+						throw new Error(auth.ok ? `No API key for ${extractionModel.provider}` : auth.error);
+					}
 					const userMessage: UserMessage = {
 						role: "user",
 						content: [{ type: "text", text: lastAssistantText! }],
@@ -467,7 +467,7 @@ export default function (pi: ExtensionAPI) {
 					const response = await complete(
 						extractionModel,
 						{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
-						{ apiKey, signal: loader.signal },
+						{ apiKey: auth.apiKey, headers: auth.headers, signal: loader.signal },
 					);
 
 					if (response.stopReason === "aborted") {


### PR DESCRIPTION
## Problem

`answer.ts` extension crashes with:

```
Extension "command:answer" error: modelRegistry.getApiKey is not a function
```

## Cause

`ModelRegistry.getApiKey()` was renamed to `getApiKeyAndHeaders()` in pi-coding-agent v0.63.0 ([pi-mono@7a786d88](https://github.com/badlogic/pi-mono/commit/7a786d88), Mar 27 2026). The new method returns a `ResolvedRequestAuth` object instead of a plain string, supporting both API keys and request headers.

The pi-mono examples (`qna.ts`) were updated in the same commit, but this extension was not — since it lives in a separate repo.

### Investigation trail

1. The error `modelRegistry.getApiKey is not a function` pointed to the `ModelRegistry` API
2. Checked pi-mono's `model-registry.ts` git history and found commit [`7a786d88`](https://github.com/badlogic/pi-mono/commit/7a786d88) (`fix(coding-agent): resolve models.json auth per request closes #1835`) which:
   - Renamed `getApiKey(model)` → `getApiKeyAndHeaders(model)`
   - Changed the return type from `Promise<string | undefined>` to `Promise<ResolvedRequestAuth>` (`{ ok: true, apiKey?, headers? } | { ok: false, error }`)
   - Updated all pi-mono examples including `qna.ts` (which this extension was originally based on)
3. Confirmed: pi-mono checkout is at v0.62.0 (still has `getApiKey`), installed pi is v0.63.1 (has `getApiKeyAndHeaders` only)

## Changes

- Replace inline `modelRegistry` type with the actual `ModelRegistry` import from `@mariozechner/pi-coding-agent`
- Use `getApiKeyAndHeaders()` which returns `{ ok, apiKey?, headers? } | { ok: false, error }`
- Pass `headers` alongside `apiKey` to `complete()` for proper auth (needed for providers with custom headers)
- Add error handling when auth resolution fails

## Notes

This is honestly my favourite pi extension — the interactive Q&A TUI for answering questions inline is brilliant. Just wanted to get it working again on 0.63+ 🙏