### PR TITLE
fix: migrate keybinding ids to namespaced pi ids

### DIFF
--- a/pi-extensions/files.ts
+++ b/pi-extensions/files.ts
@@ -939,14 +939,14 @@ const showFileSelector = async (
 
 				const kb = getEditorKeybindings();
 				if (
-					kb.matches(data, "selectUp") ||
-					kb.matches(data, "selectDown") ||
-					kb.matches(data, "selectConfirm") ||
-					kb.matches(data, "selectCancel")
+					kb.matches(data, "tui.select.up") ||
+					kb.matches(data, "tui.select.down") ||
+					kb.matches(data, "tui.select.confirm") ||
+					kb.matches(data, "tui.select.cancel")
 				) {
 					if (selectList) {
 						selectList.handleInput(data);
-					} else if (kb.matches(data, "selectCancel")) {
+					} else if (kb.matches(data, "tui.select.cancel")) {
 						done(null);
 					}
 					tui.requestRender();

--- a/pi-extensions/todos.ts
+++ b/pi-extensions/todos.ts
@@ -410,12 +410,12 @@ class TodoSelectorComponent extends Container implements Focusable {
 			this.updateList();
 			return;
 		}
-		if (kb.matches(keyData, "selectConfirm")) {
+		if (kb.matches(keyData, "tui.select.confirm")) {
 			const selected = this.filteredTodos[this.selectedIndex];
 			if (selected) this.onSelectCallback(selected);
 			return;
 		}
-		if (kb.matches(keyData, "selectCancel")) {
+		if (kb.matches(keyData, "tui.select.cancel")) {
 			this.onCancelCallback();
 			return;
 		}
@@ -574,11 +574,11 @@ class TodoDetailOverlayComponent {
 
 	handleInput(keyData: string): void {
 		const kb = getEditorKeybindings();
-		if (kb.matches(keyData, "selectCancel")) {
+		if (kb.matches(keyData, "tui.select.cancel")) {
 			this.onAction("back");
 			return;
 		}
-		if (kb.matches(keyData, "selectConfirm")) {
+		if (kb.matches(keyData, "tui.select.confirm")) {
 			this.onAction("work");
 			return;
 		}
@@ -1256,7 +1256,7 @@ function renderTodoDetail(theme: Theme, todo: TodoRecord, expanded: boolean): st
 }
 
 function appendExpandHint(theme: Theme, text: string): string {
-	return `${text}\n${theme.fg("dim", `(${keyHint("expandTools", "to expand")})`)}`;
+	return `${text}\n${theme.fg("dim", `(${keyHint("app.tools.expand", "to expand")})`)}`;
 }
 
 async function ensureTodoExists(filePath: string, id: string): Promise<TodoRecord | null> {


### PR DESCRIPTION
## Summary
- migrate legacy selector keybinding ids to `tui.select.*`
- migrate the legacy `expandTools` keybinding hint to `app.tools.expand`
- keep the extensions aligned with pi's namespaced keybinding API

## Notes
- no package-lock changes included
