### PR TITLE
fix(btw): replace replaceMessages call with state.messages assignment

### DIFF
--- a/pi-extensions/btw.ts
+++ b/pi-extensions/btw.ts
@@ -566,7 +566,7 @@ export default function (pi: ExtensionAPI) {
 
 		const seedMessages = buildSeedMessages(ctx, thread);
 		if (seedMessages.length > 0) {
-			session.agent.replaceMessages(seedMessages as typeof session.state.messages);
+			session.agent.state.messages = seedMessages as typeof session.state.messages;
 		}
 
 		const unsubscribe = session.subscribe((event: AgentSessionEvent) => {


### PR DESCRIPTION
The `replaceMessages` method does not exist on `session.agent`. The correct API is direct assignment to `session.agent.state.messages`.