### PR TITLE
fix(answer): only prefer Codex/Haiku when auth is actually configured

### DIFF
--- a/extensions/answer.ts
+++ b/extensions/answer.ts
@@ -78,7 +78,7 @@ async function selectExtractionModel(
 	modelRegistry: ModelRegistry,
 ): Promise<Model<Api>> {
 	const codexModel = modelRegistry.find("openai-codex", CODEX_MODEL_ID);
-	if (codexModel) {
+	if (codexModel && modelRegistry.hasConfiguredAuth(codexModel)) {
 		const auth = await modelRegistry.getApiKeyAndHeaders(codexModel);
 		if (auth.ok) {
 			return codexModel;
@@ -86,7 +86,7 @@ async function selectExtractionModel(
 	}
 
 	const haikuModel = modelRegistry.find("anthropic", HAIKU_MODEL_ID);
-	if (!haikuModel) {
+	if (!haikuModel || !modelRegistry.hasConfiguredAuth(haikuModel)) {
 		return currentModel;
 	}
 


### PR DESCRIPTION
Problem:
 - `/answer` can select `openai-codex/gpt-5.1-codex-mini` or `anthropic/claude-haiku-4-5` even when those providers are not actually configured.
 - This happens because `selectExtractionModel()` treats `modelRegistry.getApiKeyAndHeaders(model).ok` as “model is available”.
 - In pi, `auth.ok === true` only means auth resolution did not error; it does not guarantee that credentials exist.
 - As a result, `/answer` may choose an unconfigured preferred model instead of the current model, and extraction then fails.

 Root cause:
 - `getApiKeyAndHeaders()` can return `{ ok: true, apiKey: undefined, headers: undefined }` for an unconfigured provider.
 - The extension was using that as the availability check for Codex/Haiku.

 Fix:
 - In `selectExtractionModel()`, require `modelRegistry.hasConfiguredAuth(model)` before considering Codex or Haiku selectable.
 - Keep the existing fallback behavior to the current model unchanged.