### PR TITLE
fix(btw): use newer API

### DIFF
--- a/extensions/btw.ts
+++ b/extensions/btw.ts
@@ -566,7 +566,7 @@ export default function (pi: ExtensionAPI) {
 
 		const seedMessages = buildSeedMessages(ctx, thread);
 		if (seedMessages.length > 0) {
-			session.agent.replaceMessages(seedMessages as typeof session.state.messages);
+			session.agent.state.messages = seedMessages as typeof session.agent.state.messages;
 		}
 
 		const unsubscribe = session.subscribe((event: AgentSessionEvent) => {


### PR DESCRIPTION
Btw is currently broken in current version 0.67.68

This patch makes it work for the current versions as it seems like `replaceMessages` hsa been removed