### PR TITLE
`/answer`: Update CODEX_MODEL_ID to gpt-5.3-codex

### DIFF
--- a/extensions/answer.ts
+++ b/extensions/answer.ts
@@ -67,7 +67,7 @@ Example output:
   ]
 }`;
 
-const CODEX_MODEL_ID = "gpt-5.3";
+const CODEX_MODEL_ID = "gpt-5.3-codex";
 const HAIKU_MODEL_ID = "claude-haiku-4-5";
 
 /**


### PR DESCRIPTION
The `gpt-5.3` model not supported by `@earendil-works/pi-ai`.

There is only `gpt-5.3-chat-latest` and `gpt-5.3-codex`/`gpt-5.3-codex-spark` if you want to stay with the 5.3 series. 