### PR TITLE
fix(subagent): avoid interactive shell launch race

### DIFF
--- a/extensions/subagent.ts
+++ b/extensions/subagent.ts
@@ -552,10 +552,11 @@ export default function subagentExtension(pi: ExtensionAPI): void {
 						const initialDetails = detailsFor(spec, "running", { startedAt });
 						onUpdate?.({ content: [{ type: "text", text: partialText(initialDetails) }], details: initialDetails });
 
-						const sent = await pi.exec("tmux", tmuxArgs("send-keys", "-t", tmuxTarget, "-l", "--", childCommand));
-						if (sent.code !== 0) throw new Error(sent.stderr.trim() || "Failed to start child Pi.");
-						const entered = await pi.exec("tmux", tmuxArgs("send-keys", "-t", tmuxTarget, "Enter"));
-						if (entered.code !== 0) throw new Error(entered.stderr.trim() || "Failed to submit child command.");
+						const started = await pi.exec(
+							"tmux",
+							tmuxArgs("respawn-pane", "-k", "-c", cwd, "-t", tmuxTarget, childCommand),
+						);
+						if (started.code !== 0) throw new Error(started.stderr.trim() || "Failed to start child Pi.");
 
 						let lastPane = "";
 						let childResult: ChildResult | undefined;


### PR DESCRIPTION
Closes #51.

The subagent launcher currently creates an interactive shell and immediately types an `exec ...` command into it with `send-keys`. Fish refuses that `exec` when an asynchronous prompt job is still active, leaving the shell alive while child Pi never starts. The parent then waits forever because it sees neither `result.json` nor a dead pane.

This replaces the two `send-keys` calls with `respawn-pane -k`, launching the child command directly after `remain-on-exit` is configured. It also sets the pane's working directory explicitly. This removes the shell-startup race while preserving interactive attachment and dead-pane detection.

Validation:

- Reproduced the original failure under Fish 4.0.2 with Hydro: the first injected `exec` was refused and the child marker was not created.
- Ran the replacement launch under the same Fish/Hydro setup: the child marker was created and the pane exited with status 0 under `remain-on-exit`.
- Ran an end-to-end Pi parent/child invocation with the patched extension: the child completed, wrote `result.json` and a session JSONL file, and returned the expected `PATCHED_SUBAGENT_OK` output.
- Loaded the modified extension with Pi 0.83.0 using `--no-extensions --extension ... --list-models`.
- Ran `git diff --check`.
