### PR TITLE
Release prep: document unreleased changes and bump to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,24 @@
 
 All notable changes to agent-stuff are documented here.
 
-## Unreleased
+## 1.7.0
 
+* Replaced the `multi-edit` extension with `unified-edit`: the `edit` tool now takes a single required text payload (a marked row edit script or a Codex/apply_patch-style patch) with preflight validation, and coerces stray `patch`/`input`/`content` arguments into the payload. This retires the optional `path`/`oldText`/`newText`/`multi`/`patch` parameter surface, whose "`patch` parameter is mutually exclusive with path/oldText/newText/multi" error triggered on GPT-5.x tool calls that emit `null` or redundant classic parameters alongside `patch`.
+* Replaced the `loop` extension with an opt-in `goal` extension backed by session goals, with automatic continuation and the `get_goal`, `create_goal`, and `update_goal` tools.
+* Added a `subagent` extension that serially runs one observable Pi child at a time in tmux.
+* Added a `no-sleep` extension with `/no-sleep` macOS `caffeinate` integration.
+* Added a `trust-github-repos` extension that automatically trusts GitHub checkouts owned by `earendil-works` or `mitsuhiko`.
+* Added an idle continue shortcut (`shift+option+enter`) that sends `continue` only when the agent is stopped.
+* Added the `dayowl` and `modern-dark` themes.
+* Added an optional headless Chrome mode, improved mobile emulation, and profile isolation to the `web-browser` skill, with Chrome extensions disabled in headless mode.
+* Added a cost/session column and provider grouping to `/session-breakdown`, and skipped faux provider sessions.
+* Added bash status to the prompt editor mode label.
+* Migrated extensions and skills to the `@earendil-works` Pi packages.
+* Removed the `context` and `go-to-bed` extensions, the `mermaid` skill, and the prebuilt `distributions/` packages.
 * Fixed the notify extension leaking OSC 8 hyperlink text into fullscreen prompt editors.
+* Fixed `/answer` to handle question extraction failures.
+* Fixed the `web-browser` skill to support statement eval syntax.
+* Removed the `Ctrl+Shift+F` shortcut from `/files`.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to agent-stuff are documented here.
 * Added a `no-sleep` extension with `/no-sleep` macOS `caffeinate` integration.
 * Added a `trust-github-repos` extension that automatically trusts GitHub checkouts owned by `earendil-works` or `mitsuhiko`.
 * Added an idle continue shortcut (`shift+option+enter`) that sends `continue` only when the agent is stopped.
+* Added an `audio-transcription` skill with local model precaching.
 * Added the `dayowl` and `modern-dark` themes.
 * Added an optional headless Chrome mode, improved mobile emulation, and profile isolation to the `web-browser` skill, with Chrome extensions disabled in headless mode.
 * Added a cost/session column and provider grouping to `/session-breakdown`, and skipped faux provider sessions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mitsupi",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Armin's pi coding agent commands, skills, extensions, and themes",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The npm package (mitsupi@1.6.0, published 2026-04-17) still ships the old multi-edit extension, whose 'patch is mutually exclusive with path/oldText/newText/multi' check hard-fails GPT-5.x edit tool calls that emit null or redundant classic parameters alongside patch. The repo replaced multi-edit with unified-edit in 274fe04 but no release has shipped it. Document the unreleased changes and bump the version so tagging 1.7.0 publishes via the existing npm-publish workflow.